### PR TITLE
feat: make scrollbar slider transparent

### DIFF
--- a/themes/windows-xp-color-theme.json
+++ b/themes/windows-xp-color-theme.json
@@ -619,9 +619,9 @@
     "breadcrumb.foreground": "#555",
     "breadcrumb.focusForeground": "#000",
     // Scrollbar
-    "scrollbarSlider.background": "#c1d3fb",
-    "scrollbarSlider.hoverBackground": "#d6e7ff",
-    "scrollbarSlider.activeBackground": "#a1bcfa",
+    "scrollbarSlider.background": "#c1d3fbb0",
+    "scrollbarSlider.hoverBackground": "#a1bcfab0",
+    "scrollbarSlider.activeBackground": "#7fa2fab0",
     // Widgets
     "widget.shadow": "#00000015",
     "editorWidget.background": "#ece9d8",


### PR DESCRIPTION
Previously, the scrollbar sliders were opaque which made all highlights/gutters in the minimap (on the right edge of the editor) behind the slider invisible. It is a common practice to make the scrollbar slider transparent.[^1]

|Before|After|
|-|-|
|![xp-theme-branches-before](https://user-images.githubusercontent.com/38782922/212668007-2f29cded-5d87-4850-a116-d61e32e7e371.gif)|![xp-theme-branches-after](https://user-images.githubusercontent.com/38782922/212669016-acb51519-7cf9-41ce-8374-00a1c8744b3c.gif)|
|![xp-theme-minimap-before](https://user-images.githubusercontent.com/38782922/212669000-5acf1162-d853-4929-bf6e-dcfd68ac5209.gif)|![xp-theme-minimap-after](https://user-images.githubusercontent.com/38782922/212669096-817d740f-f1a2-4853-9fcb-3b18785c422f.gif)|

Design note: I chose the alpha value so that it looks ok on my screen. I used the old active color als hover color and linearily extrapolated the new active color from the other colors. I am not designer. If you do not find the choice of the colors perfect or if they have been copied exactly from Luna, I am open to your suggestions for improvement. :)

[^1]: https://sourcegraph.com/search?q=%22scrollbarSlider.background%22%3A&groupBy=repo