### PR TITLE
fix token color for `support.variable`

### DIFF
--- a/themes/windows-xp-color-theme.json
+++ b/themes/windows-xp-color-theme.json
@@ -128,7 +128,8 @@
     },
     {
       "scope": [
-        "variable"
+        "variable",
+        "support.variable"
       ],
       "settings": {
         "foreground": "#e36209"
@@ -259,15 +260,6 @@
         "foreground": "#005cc5"
       },
       "name": "Support.constant"
-    },
-    {
-      "scope": [
-        "support.variable"
-      ],
-      "settings": {
-        "foreground": "#005cc5"
-      },
-      "name": "Support.variable"
     },
     {
       "scope": [


### PR DESCRIPTION
The former color set did not differentiate between the token scopes `support` and `support.variable`. However, the difference is relevant in some context such as https://github.com/James-Yu/LaTeX-Workshop/issues/3720#issuecomment-1433407133. Taking a look at [microsoft/vscode](https://github.com/microsoft/vscode), most built-in themes seem to assign the same color for the `variable` and `support.variable` scopes, so I applied the same change here.

However, please recheck as I don't know to systematically check the new token colors for consistency.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/38782922/221810505-304c0a7b-3a3a-4695-bdbf-cbda949aa737.png)|![image](https://user-images.githubusercontent.com/38782922/221810662-d99a83a2-51d9-4875-8465-52b12220af25.png)|

(Note the color of `doi` in the last line.)

Thanks to @James-Yu for the pointer!